### PR TITLE
Math 135 Corrections

### DIFF
--- a/MATH135/EP10.tex
+++ b/MATH135/EP10.tex
@@ -65,9 +65,9 @@
           \begin{align*}
             \frac{(\sqrt2-i)^2}{(\sqrt2+i)(1-\sqrt2i)}
              & = \frac{(1-2\sqrt{2}i)(\sqrt{2}-i)(1+\sqrt{2}i)}{(3)(3)} \\
-             & = -\frac{(5-\sqrt2i)(\sqrt2-i)}{9}                       \\
-             & = -\frac{4\sqrt2-7i}{9}                                  \\
-             & = -\frac{4\sqrt2}{9}+\frac{7}{9}i \qedhere
+             & = \frac{(5-\sqrt2i)(\sqrt2-i)}{9}                       \\
+             & = \frac{4\sqrt2-7i}{9}                                  \\
+             & = \frac{4\sqrt2}{9}-\frac{7}{9}i \qedhere
           \end{align*}
         \end{proof}
   \item $(\sqrt5-i\sqrt3)^4$

--- a/MATH135/FE2020W.tex
+++ b/MATH135/FE2020W.tex
@@ -206,7 +206,7 @@
   Let $p$ be an odd prime, that is, $p \neq 2$, and $a$ be an odd integer not a multiple of $p$.
   By \FLT, $a^{p-1} \equiv 1 \pmod p$.
   Since $a$ is odd, $a \equiv 1 \pmod 2$ and $a^{p-1} \equiv 1 \pmod 2$ by CP\@.
-  Then, by SMT, $a^{p-1} \equiv 2 \pmod{2p}$.
+  Then, by SMT, $a^{p-1} \equiv 1 \pmod{2p}$.
 \end{prf}
 
 \begin{prob}


### PR DESCRIPTION
I believe there was an erroneous negative sign added on the \frac{(5-\sqrt2i)(\sqrt2-i)}{9} step. 